### PR TITLE
Send the service name back with the validation msg

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,7 +69,8 @@ async def consumer(client):
             bucket = BUCKET_MAP[doc["category"]]
             await store(payload, bucket)
             produce_queue.append(
-                {"validation": "handoff", "payload_id": doc["payload_id"]}
+                {"validation": "handoff", "payload_id": doc["payload_id"],
+                 "service": "buck-it"}
             )
     await asyncio.sleep(0.5)
 


### PR DESCRIPTION
We should send the service name back so we can track who is doing
handoffs. If more services use "handoff" type procedures, we'd want to
know who did the operation.